### PR TITLE
Changed model_abbrs argument to itself (i.e. what is passed to functi…

### DIFF
--- a/R/qra_fit_convenience.R
+++ b/R/qra_fit_convenience.R
@@ -311,7 +311,7 @@ load_covid_forecasts_relative_horizon <- function(
       purrr::map_dfr(
         tail(monday_dates, 1),
         load_covid_forecasts,
-        model_abbrs = candidate_model_abbreviations_to_include,
+        model_abbrs = model_abbrs,
         timezero_window_size = timezero_window_size,
         types = "point",
         targets = targets,


### PR DESCRIPTION
…on) so that using a subset of candidate_model_abbreviations_to_include will give the corresponding subset of forecasts when include_null_point_forecasts = TRUE.