### PR TITLE
New as.data.frame and str methods for QuantileForecastMatrix

### DIFF
--- a/R/QuantileForecastMatrix.R
+++ b/R/QuantileForecastMatrix.R
@@ -1,3 +1,4 @@
+
 #' Check if object is of class QuantileForecastMatrix
 #'
 #' @param qfm an object that may be a QuantileForecastMatrix
@@ -222,29 +223,29 @@ new_QuantileForecastMatrix_from_df <- function(
 #'
 #' @export
 as.data.frame.QuantileForecastMatrix <- function(qfm) {
-  purrr::map_dfr(seq_len(nrow(qfm)),
-    function(i) {
-      purrr::map_dfr(seq_len(ncol(qfm)),
-        function(j) {
-          if(is.na(qfm[i,j])) {
-            return(NULL)
-          }
-          result <- bind_cols(
-              attr(qfm, 'row_index')[i, ],
-              attr(qfm, 'col_index')[j, ]
-            )
+  dplyr::full_join(attr(qfm, "col_index"), attr(qfm, "row_index"), by = character()) %>% 
+  dplyr::mutate(
+    !!attr(qfm, "quantile_value_col") := qfm %>% `attributes<-`(NULL),
+    !!attr(qfm, "quantile_name_col") := as.numeric(!!sym(attr(qfm, "quantile_name_col")))
+  ) %>% 
+  dplyr::relocate(
+    attr(qfm, "model_col"),
+    attr(qfm, "quantile_name_col"),
+    attr(qfm, "quantile_value_col")
+  ) %>% 
+  dplyr::filter(!is.na(!!sym(attr(qfm, "quantile_value_col"))))
+}
 
-          result[[attr(qfm, 'quantile_value_col')]] <-
-            unclass(qfm)[i, j]
-
-          result[[attr(qfm, 'quantile_name_col')]] <-
-            as.numeric(result[[attr(qfm, 'quantile_name_col')]])
-
-          return(result)
-        }
-      )
-    }
-  )
+#' Convenience `str` method for QuantileForecastMatrix class which
+#' avoids `seq_len(ncol(qfm))` errors and warnings
+#' 
+#' @param qfm wide matrix representation of forecasts
+#' 
+#' @return none
+#' 
+#' @export
+str.QuantileForecastMatrix <- function(qfm) {
+  str(unclass(qfm))
 }
 
 


### PR DESCRIPTION
This `as.data.frame` method using `dplyr::full_join` is much faster than version using `purrr`.
I added the str method just because I always forget to type `unclass`...
All unit tests pass.