### PR TITLE
small change in calc_sd_check needed to pass unit test

### DIFF
--- a/R/model_eligibility.R
+++ b/R/model_eligibility.R
@@ -645,10 +645,7 @@ calc_sd_check <- function(
             result[['sd_eligibility']] <- 'eligible'
           }
 
-          if (!is.null(sd_check_table_path) | !is.null(sd_check_plot_path)) {
-            result$mean_ahead <- mean_ahead
-          }
-          
+          result$mean_ahead <- mean_ahead          
           return(result)
         }
       )


### PR DESCRIPTION
I added the -mean_ahead in the return arg after unit testing while making the CDC comparisons... but everything passes now